### PR TITLE
implement modifications needed for working with AssumeRoleWithWebIdentity

### DIFF
--- a/src/connectors/controllers.js
+++ b/src/connectors/controllers.js
@@ -2,12 +2,13 @@ const logger = require('./logger');
 const openid = require('../openid');
 
 module.exports = respond => ({
-  authorize: (client_id, scope, state, response_type) => {
+  authorize: (client_id, scope, state, response_type, redirect_uri) => {
     const authorizeUrl = openid.getAuthorizeUrl(
       client_id,
       scope,
       state,
-      response_type
+      response_type,
+      redirect_uri
     );
     logger.info('Redirecting to authorizeUrl');
     logger.debug('Authorize Url is: %s', authorizeUrl, {});

--- a/src/connectors/lambda/authorize.js
+++ b/src/connectors/lambda/authorize.js
@@ -6,13 +6,15 @@ module.exports.handler = (event, context, callback) => {
     client_id,
     scope,
     state,
-    response_type
+    response_type,
+    redirect_uri
   } = event.queryStringParameters;
 
   controllers(responder(callback)).authorize(
     client_id,
     scope,
     state,
-    response_type
+    response_type,
+    redirect_uri
   );
 };

--- a/src/connectors/web/handlers.js
+++ b/src/connectors/web/handlers.js
@@ -19,7 +19,7 @@ module.exports = {
         req.query.client_id
       }&scope=${req.query.scope}&state=${req.query.state}&response_type=${
         req.query.response_type
-      }`
+      }&redirect_uri=${req.query.redirect_uri}`
     ),
   openIdConfiguration: (req, res) => {
     controllers(responder(res)).openIdConfiguration(

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -22,7 +22,7 @@ module.exports = {
     };
     logger.debug('Signing payload %j', enrichedPayload, {});
     return jwt.sign(enrichedPayload, cert, {
-      expiresIn: '1h',
+      expiresIn: '10m',
       algorithm: 'RS256',
       keyid: KEY_ID
     });

--- a/src/github.js
+++ b/src/github.js
@@ -52,10 +52,10 @@ const gitHubGet = (url, accessToken) =>
 module.exports = (apiBaseUrl, loginBaseUrl) => {
   const urls = getApiEndpoints(apiBaseUrl, loginBaseUrl || apiBaseUrl);
   return {
-    getAuthorizeUrl: (client_id, scope, state, response_type) =>
+    getAuthorizeUrl: (client_id, scope, state, response_type, redirect_uri) =>
       `${urls.oauthAuthorize}?client_id=${client_id}&scope=${encodeURIComponent(
         scope
-      )}&state=${state}&response_type=${response_type}`,
+      )}&state=${state}&response_type=${response_type}&redirect_uri=${redirect_uri}`,
     getUserDetails: accessToken =>
       gitHubGet(urls.userDetails, accessToken).then(check),
     getUserEmails: accessToken =>

--- a/src/github.js
+++ b/src/github.js
@@ -14,6 +14,7 @@ const getApiEndpoints = (
 ) => ({
   userDetails: `${apiBaseUrl}/user`,
   userEmails: `${apiBaseUrl}/user/emails`,
+  userTeams: `${apiBaseUrl}/user/teams`,
   oauthToken: `${loginBaseUrl}/login/oauth/access_token`,
   oauthAuthorize: `${loginBaseUrl}/login/oauth/authorize`
 });
@@ -59,6 +60,8 @@ module.exports = (apiBaseUrl, loginBaseUrl) => {
       gitHubGet(urls.userDetails, accessToken).then(check),
     getUserEmails: accessToken =>
       gitHubGet(urls.userEmails, accessToken).then(check),
+    getUserTeams: accessToken =>
+      gitHubGet(`${urls.userTeams}?per_page=100`, accessToken).then(check),
     getToken: (code, state) => {
       const data = {
         // OAuth required fields

--- a/src/github.pact.test.js
+++ b/src/github.pact.test.js
@@ -226,6 +226,105 @@ describe('With an increased jasmine timeout', () => {
       });
     });
 
+    describe('UserTeams endpoint', () => {
+      const userTeamsRequest = {
+        uponReceiving: 'a request for user teams',
+        withRequest: {
+          method: 'GET',
+          path: '/user/teams',
+          query: 'per_page=100',
+          headers: {
+            Accept: 'application/vnd.github.v3+json',
+            Authorization: `token THIS_IS_MY_TOKEN`
+          }
+        }
+      };
+      describe('When the access token is good', () => {
+        const EXPECTED_BODY = [{ id: 1234, name: "Team A" }, { id: 5678, name: "Team B"}];
+        beforeEach(() => {
+          const interaction = {
+            ...userTeamsRequest,
+            state: 'Where the access token is good',
+            willRespondWith: {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: EXPECTED_BODY
+            }
+          };
+          return provider.addInteraction(interaction);
+        });
+
+        // add expectations
+        it('returns a sucessful body', done =>
+          github(PACT_BASE_URL)
+            .getUserTeams('THIS_IS_MY_TOKEN')
+            .then(response => {
+              expect(response).toEqual(EXPECTED_BODY);
+              done();
+            }));
+      });
+      describe('When the access token is bad', () => {
+        const EXPECTED_ERROR = {
+          error: 'This is an error',
+          error_description: 'This is a description'
+        };
+        beforeEach(() => {
+          const interaction = {
+            ...userTeamsRequest,
+            state: 'Where the access token is bad',
+            willRespondWith: {
+              status: 400,
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: EXPECTED_ERROR
+            }
+          };
+          return provider.addInteraction(interaction);
+        });
+
+        // add expectations
+        it('rejects the promise', done => {
+          github(PACT_BASE_URL)
+            .getUserTeams('THIS_IS_MY_TOKEN')
+            .catch(() => {
+              done();
+            });
+        });
+      });
+      describe('When there is a server error response', () => {
+        const EXPECTED_ERROR = {
+          error: 'This is an error',
+          error_description: 'This is a description'
+        };
+        beforeEach(() => {
+          const interaction = {
+            ...userTeamsRequest,
+            state: 'Where there is a server error response',
+            willRespondWith: {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json'
+              },
+              body: EXPECTED_ERROR
+            }
+          };
+          return provider.addInteraction(interaction);
+        });
+
+        // add expectations
+        it('rejects the promise', done => {
+          github(PACT_BASE_URL)
+            .getUserTeams('THIS_IS_MY_TOKEN')
+            .catch(() => {
+              done();
+            });
+        });
+      });
+    });
+
     describe('Authorization endpoint', () => {
       describe('always', () => {
         it('returns a redirect url', () => {

--- a/src/github.pact.test.js
+++ b/src/github.pact.test.js
@@ -333,10 +333,11 @@ describe('With an increased jasmine timeout', () => {
               'client_id',
               'scope',
               'state',
-              'response_type'
+              'response_type',
+              'redirect_uri'
             )
           ).to.equal(
-            `${PACT_BASE_URL}/login/oauth/authorize?client_id=client_id&scope=scope&state=state&response_type=response_type`
+            `${PACT_BASE_URL}/login/oauth/authorize?client_id=client_id&scope=scope&state=state&response_type=response_type&redirect_uri=redirect_uri`
           );
         });
       });

--- a/src/openid.js
+++ b/src/openid.js
@@ -77,13 +77,9 @@ const getTokens = (code, state, host) =>
       // exp - expiry time for the id token (seconds since epoch in UTC)
       // iat - time that the JWT was issued (seconds since epoch in UTC)
 
-      return new Promise(resolve => {
-        const payload = {
-          // This was commented because Cognito times out in under a second
-          // and generating the userInfo takes too long.
-          // It means the ID token is empty except for metadata.
-          //  ...userInfo,
-        };
+      return new Promise(async (resolve) => {
+        // TODO error handling
+        const payload = await getUserInfo(githubToken.access_token);
 
         const idToken = crypto.makeIdToken(payload, host);
         const tokenResponse = {

--- a/src/openid.js
+++ b/src/openid.js
@@ -50,7 +50,17 @@ const getUserInfo = accessToken =>
       .then(userTeams => {
         logger.debug('Fetched user teams: %j', userTeams, {});
         const claims = {
-          teams: userTeams.map(({id}) => id)
+          'https://aws.amazon.com/tags': {
+            'principal_tags': userTeams.map(({id}) => id).reduce((obj, id) => {
+              // why prefix keys with `t`? some minimal namespacing in case we need
+              // to cram any other information into this map down the line and also
+              // will prevent any systems interpreting the key as an integer and doing
+              // funny things with leading zeros etc.
+              // eslint-disable-next-line no-param-reassign
+              obj[`t${id}`] = ["t"];  // `t` for "true" as we can only have str values
+              return obj;
+            } , {})
+          }
         };
         logger.debug('Resolved claims: %j', claims, {});
         return claims;
@@ -143,7 +153,7 @@ const getConfigFor = host => ({
     'updated_at',
     'iss',
     'aud',
-    'teams'
+    'https://aws.amazon.com/tags'
   ]
 });
 

--- a/src/openid.js
+++ b/src/openid.js
@@ -74,8 +74,8 @@ const getUserInfo = accessToken =>
     return mergedClaims;
   });
 
-const getAuthorizeUrl = (client_id, scope, state, response_type) =>
-  github().getAuthorizeUrl(client_id, scope, state, response_type);
+const getAuthorizeUrl = (client_id, scope, state, response_type, redirect_uri) =>
+  github().getAuthorizeUrl(client_id, scope, state, response_type, redirect_uri);
 
 const getTokens = (code, state, host) =>
   github()

--- a/src/openid.js
+++ b/src/openid.js
@@ -44,6 +44,16 @@ const getUserInfo = accessToken =>
         };
         logger.debug('Resolved claims: %j', claims, {});
         return claims;
+      }),
+   github()
+      .getUserTeams(accessToken)
+      .then(userTeams => {
+        logger.debug('Fetched user teams: %j', userTeams, {});
+        const claims = {
+          teams: userTeams.map(({id}) => id)
+        };
+        logger.debug('Resolved claims: %j', claims, {});
+        return claims;
       })
   ]).then(claims => {
     const mergedClaims = claims.reduce(
@@ -108,7 +118,7 @@ const getConfigFor = host => ({
   // end_session_endpoint: 'https://server.example.com/connect/end_session',
   jwks_uri: `https://${host}/.well-known/jwks.json`,
   // registration_endpoint: 'https://server.example.com/connect/register',
-  scopes_supported: ['openid', 'read:user', 'user:email'],
+  scopes_supported: ['openid', 'read:user', 'user:email', 'read:org'],
   response_types_supported: [
     'code',
     'code id_token',
@@ -132,7 +142,8 @@ const getConfigFor = host => ({
     'email_verified',
     'updated_at',
     'iss',
-    'aud'
+    'aud',
+    'teams'
   ]
 });
 

--- a/src/openid.test.js
+++ b/src/openid.test.js
@@ -69,7 +69,9 @@ describe('openid domain layer', () => {
               sub: 'undefined',
               updated_at: 1200285215,
               website: 'website',
-              teams: [4321, 5432]
+              "https://aws.amazon.com/tags": {
+                "principal_tags": {"t4321": ["t"], "t5432": ["t"]}
+              }
             });
           });
         });
@@ -190,7 +192,7 @@ describe('openid domain layer', () => {
             'updated_at',
             'iss',
             'aud',
-            'teams'
+            'https://aws.amazon.com/tags'
           ],
           display_values_supported: ['page', 'popup'],
           id_token_signing_alg_values_supported: ['RS256'],

--- a/src/openid.test.js
+++ b/src/openid.test.js
@@ -20,20 +20,20 @@ describe('openid domain layer', () => {
     github.mockImplementation(() => githubMock);
   });
 
-  describe('userinfo function', () => {
-    const mockEmailsWithPrimary = withPrimary => {
-      githubMock.getUserEmails.mockImplementation(() =>
-        Promise.resolve([
-          {
-            primary: false,
-            email: 'not-this-email@example.com',
-            verified: false
-          },
-          { primary: withPrimary, email: 'email@example.com', verified: true }
-        ])
-      );
-    };
+  const mockEmailsWithPrimary = withPrimary => {
+    githubMock.getUserEmails.mockImplementation(() =>
+      Promise.resolve([
+        {
+          primary: false,
+          email: 'not-this-email@example.com',
+          verified: false
+        },
+        { primary: withPrimary, email: 'email@example.com', verified: true }
+      ])
+    );
+  };
 
+  describe('userinfo function', () => {
     describe('with a good token', () => {
       describe('with complete user details', () => {
         beforeEach(() => {
@@ -100,6 +100,18 @@ describe('openid domain layer', () => {
             scope: 'scope1,scope2'
           })
         );
+        githubMock.getUserDetails.mockImplementation(() =>
+          Promise.resolve({
+            sub: 'Some sub',
+            name: 'some name',
+            login: 'username',
+            html_url: 'some profile',
+            avatar_url: 'picture.jpg',
+            blog: 'website',
+            updated_at: '2008-01-14T04:33:35Z'
+          })
+        );
+        mockEmailsWithPrimary(true);
         crypto.makeIdToken.mockImplementation(() => 'ENCODED TOKEN');
       });
 
@@ -124,7 +136,7 @@ describe('openid domain layer', () => {
         );
       });
       it('fails', () =>
-        expect(openid.getUserInfo('bad token', 'two', 'three')).to.eventually.be
+        expect(openid.getTokens()).to.eventually.be
           .rejected);
     });
   });


### PR DESCRIPTION
https://trello.com/c/ISWQzCgK

These are the main functional modifications needed to https://github.com/TimothyJones/github-cognito-openid-wrapper to make it behave how we want.

 - All claim information is included in the token returned by the `/token` endpoint.
 - The `redirect_uri` parameter is included in redirection of the `/authorize` endpoint. This is needed to allow us to use a dynamic port number on the localhost callback listener.
 - Team membership information is fetched from the github api and included in the aws-specific claim `https://aws.amazon.com/tags`.