### PR TITLE
Handle non-capitalised content-type header.

### DIFF
--- a/src/connectors/lambda/open-id-configuration.js
+++ b/src/connectors/lambda/open-id-configuration.js
@@ -5,7 +5,7 @@ const controllers = require('../controllers');
 module.exports.handler = (event, context, callback) => {
   controllers(responder(callback)).openIdConfiguration(
     auth.getIssuer(
-      event.headers.Host,
+      event.headers.Host || event.headers.host,
       event.requestContext && event.requestContext.stage
     )
   );

--- a/src/connectors/lambda/token.js
+++ b/src/connectors/lambda/token.js
@@ -4,8 +4,8 @@ const auth = require('./util/auth');
 const controllers = require('../controllers');
 
 const parseBody = event => {
-  const contentType = event.headers['Content-Type'];
-  if (event.body) {
+  const contentType = event.headers['Content-Type'] || event.headers['content-type'];
+  if (event.body && contentType) {
     if (contentType.startsWith('application/x-www-form-urlencoded')) {
       return qs.parse(event.body);
     }
@@ -27,7 +27,7 @@ module.exports.handler = (event, context, callback) => {
     code,
     state,
     auth.getIssuer(
-      event.headers.Host,
+      event.headers.Host || event.headers.host,
       event.requestContext && event.requestContext.stage
     )
   );

--- a/src/connectors/lambda/util/auth.js
+++ b/src/connectors/lambda/util/auth.js
@@ -4,7 +4,7 @@ module.exports = {
   getBearerToken: req =>
     new Promise((resolve, reject) => {
       // This method implements https://tools.ietf.org/html/rfc6750
-      const authHeader = req.headers.Authorization;
+      const authHeader = req.headers.Authorization || req.headers.authorization;
       logger.debug('Detected authorization header %s', authHeader);
       if (authHeader) {
         // Section 2.1 Authorization request header
@@ -22,8 +22,9 @@ module.exports = {
         );
         resolve(req.queryStringParameters.access_token);
       } else if (
-        req.headers['Content-Type'] === 'application/x-www-form-urlencoded' &&
-        req.body
+        (req.headers['Content-Type'] || req.headers['content-type'])
+          === 'application/x-www-form-urlencoded'
+        && req.body
       ) {
         // Section 2.2 form encoded body parameter
         const body = JSON.parse(req.body);


### PR DESCRIPTION
This is a issue caused by some HTTP libs like to lowercase there headers without you telling them. it makes this bit of code go bang if it cant find a `content-type`