### PR TITLE
deployment: add IP-restrictions to most apigateway endpoints

### DIFF
--- a/ci/deploy.default.vars.yml
+++ b/ci/deploy.default.vars.yml
@@ -1,3 +1,8 @@
 github-oidc-proxy-git-branch: master
+github-oidc-proxy-git-uri: git@github.com:alphagov/github-oidc-proxy.git
+allowed-ips-git-branch: master
+allowed-ips-git-uri: git@github.com:alphagov/tech-ops-private.git
+allowed-ips-git-tf-module-path: reliability-engineering/terraform/modules/gds-ips
+allowed-ips-git-tf-output-name: gds_cidr_blocks
 background-image: ""
 meta-suffix: ""

--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -8,8 +8,16 @@ resources:
   type: git
   source:
     branch: ((github-oidc-proxy-git-branch))
-    uri: git@github.com:alphagov/github-oidc-proxy.git
+    uri: ((github-oidc-proxy-git-uri))
     private_key: ((github-oidc-proxy-git-ssh-private-key))
+
+- name: allowed-ips-git
+  icon: github
+  type: git
+  source:
+    branch: ((allowed-ips-git-branch))
+    uri: ((allowed-ips-git-uri))
+    private_key: ((allowed-ips-git-ssh-private-key))
 
 jobs:
 
@@ -22,15 +30,23 @@ jobs:
     file: github-oidc-proxy-git/ci/deploy.yml
     vars:
       github-oidc-proxy-git-branch: ((github-oidc-proxy-git-branch))
+      github-oidc-proxy-git-uri: ((github-oidc-proxy-git-uri))
+      allowed-ips-git-branch: ((allowed-ips-git-branch))
+      allowed-ips-git-uri: ((allowed-ips-git-uri))
+      allowed-ips-git-tf-module-path: ((allowed-ips-git-tf-module-path))
+      allowed-ips-git-tf-output-name: ((allowed-ips-git-tf-output-name))
       background-image: ((background-image))
       meta-suffix: ((meta-suffix))
 
 - name: deploy-staging
   serial: true
   plan:
-  - get: github-oidc-proxy-git
-    trigger: true
-    passed: [update-pipeline]
+  - in_parallel:
+    - get: github-oidc-proxy-git
+      trigger: true
+      passed: [update-pipeline]
+    - get: allowed-ips-git
+      trigger: false
   - task: build-dist
     params:
       JWKS_PUBLIC_KEY: ((staging-jwks-public-key))
@@ -45,6 +61,9 @@ jobs:
       TF_VAR_domain_root_zone_tfstate_s3_key: ((staging-domain-root-zone-tfstate-s3-key))
       TF_VAR_domain_root_zone_tfstate_id_output_name: ((staging-domain-root-zone-tfstate-id-output-name))
       TF_VAR_domain_subdomain: ((staging-domain-subdomain))
+      TF_VAR_allowed_ips: ((readonly_egress_ips))
+      TF_VAR_allowed_ips_tf_module_output_name: ((allowed-ips-git-tf-output-name))
+      ALLOWED_IPS_TF_MODULE_PATH: ((allowed-ips-git-tf-module-path))
       TERRAFORM_STATE_BUCKET: ((staging-terraform-state-bucket))
       TERRAFORM_STATE_REGION: ((staging-terraform-state-region))
       ENVIRONMENT_NAME: staging((meta-suffix))
@@ -59,9 +78,13 @@ jobs:
 - name: deploy-production
   serial: true
   plan:
-  - get: github-oidc-proxy-git
-    trigger: true
-    passed: [deploy-staging]
+  - in_parallel:
+    - get: github-oidc-proxy-git
+      trigger: true
+      passed: [deploy-staging]
+    - get: allowed-ips-git
+      trigger: false
+      passed: [deploy-staging]
   - task: build-dist
     params:
       JWKS_PUBLIC_KEY: ((production-jwks-public-key))
@@ -76,6 +99,9 @@ jobs:
       TF_VAR_domain_root_zone_tfstate_s3_key: ((production-domain-root-zone-tfstate-s3-key))
       TF_VAR_domain_root_zone_tfstate_id_output_name: ((production-domain-root-zone-tfstate-id-output-name))
       TF_VAR_domain_subdomain: ((production-domain-subdomain))
+      TF_VAR_allowed_ips: ((readonly_egress_ips))
+      TF_VAR_allowed_ips_tf_module_output_name: ((allowed-ips-git-tf-output-name))
+      ALLOWED_IPS_TF_MODULE_PATH: ((allowed-ips-git-tf-module-path))
       TERRAFORM_STATE_BUCKET: ((production-terraform-state-bucket))
       TERRAFORM_STATE_REGION: ((production-terraform-state-region))
       ENVIRONMENT_NAME: production((meta-suffix))

--- a/ci/tasks/terraform.yml
+++ b/ci/tasks/terraform.yml
@@ -6,6 +6,8 @@ image_resource:
     tag: sha256:4db24e98d6585ba2466c47f502f346b843db17b83d49303ce0cfb93c54a5a11f  # terraform 0.14.4
 inputs:
 - name: github-oidc-proxy-git
+- name: allowed-ips-git
+  optional: true
 outputs:
 - name: terraform-outputs
 params:
@@ -13,6 +15,7 @@ params:
   TERRAFORM_STATE_REGION:
   ENVIRONMENT_NAME:
   DEPLOYER_ROLE_ARN:
+  ALLOWED_IPS_TF_MODULE_PATH:
 run:
   dir: github-oidc-proxy-git/terraform
   path: /bin/ash
@@ -22,6 +25,13 @@ run:
     - |
       export TF_VAR_deployer_role_arn="${DEPLOYER_ROLE_ARN}"
       export TF_VAR_environment_name="${ENVIRONMENT_NAME}"
+
+      ALLOWED_IPS_TARGET="../../allowed-ips-git/${ALLOWED_IPS_TF_MODULE_PATH}"
+      if [ -e $ALLOWED_IPS_TARGET ] ; then
+        echo "Symlinking allowed-ips module..."
+        rm -r ./modules/allowed-ips
+        ln -s "../${ALLOWED_IPS_TARGET}" ./modules/allowed-ips
+      fi
 
       terraform init -input=false \
         -backend-config "bucket=${TERRAFORM_STATE_BUCKET}" \

--- a/terraform/allowed-ips.tf
+++ b/terraform/allowed-ips.tf
@@ -1,0 +1,40 @@
+module "allowed_ips" {
+  for_each = local.allowed_ips_tf_modules
+
+  source = "./modules/allowed-ips"
+}
+
+resource "aws_api_gateway_rest_api_policy" "allowed_ips" {
+  for_each = local.allowed_ips_policies
+
+  rest_api_id = aws_api_gateway_rest_api.github_oidc_proxy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Effect = "Allow"
+          Principal = "*"
+          Action = "execute-api:Invoke"
+          Resource = "${aws_api_gateway_rest_api.github_oidc_proxy.execution_arn}/*"
+        },
+      ],
+      # not all endpoints can be IP-restricted: IAM itself needs to hit at least /.well-known/jwks.json
+      # from an unpredictable source ip.
+      [
+        for path in ["/token", "/authorize", "/userinfo"] : {
+          Effect = "Deny"
+          Principal = "*"
+          Action = "execute-api:Invoke"
+          Resource = "${aws_api_gateway_rest_api.github_oidc_proxy.execution_arn}/*/*${path}"
+          Condition = {
+            NotIpAddress = {
+              "aws:SourceIp" = each.value.final_ip_list
+            }
+          }
+        }
+      ],
+    )
+  })
+}

--- a/terraform/github-oidc-proxy.tf
+++ b/terraform/github-oidc-proxy.tf
@@ -82,7 +82,10 @@ resource "aws_api_gateway_deployment" "current" {
   rest_api_id = aws_api_gateway_rest_api.github_oidc_proxy.id
 
   triggers = {
-    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.github_oidc_proxy.body))
+    api_config = jsonencode(aws_api_gateway_rest_api.github_oidc_proxy.body)
+    allowed_ips_policies = jsonencode(
+      { for k, v in aws_api_gateway_rest_api_policy.allowed_ips : k => jsonencode(jsondecode(v.policy)) }
+    )
   }
 
   lifecycle {

--- a/terraform/modules/allowed-ips/README
+++ b/terraform/modules/allowed-ips/README
@@ -1,0 +1,2 @@
+Replace this directory with a symlink to a real allowed-ips module if desired.
+(This is a workaround for terraform not supporting variables in module paths)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "environment_name" {
-  default = "frank"
+  default = "dev"
 }
 
 variable "deployer_role_arn" {
@@ -23,6 +23,14 @@ variable "domain_root_zone_tfstate_id_output_name" {
 }
 
 variable "domain_subdomain" {
+  default = ""
+}
+
+variable "allowed_ips_tf_module_output_name" {
+  default = ""
+}
+
+variable "allowed_ips" {
   default = ""
 }
 


### PR DESCRIPTION
https://trello.com/c/CzpMog66

This is a little more complex than I'd like because:

- It needs to pull the IP list from a foreign terraform module.
- I've tried to keep the infra code free from hard-coded settings and make features optional.
- The terraform provider has an annoying bug around handling of aws_api_gateway_rest_api_policy resources: https://github.com/hashicorp/terraform-provider-aws/issues/17341