### PR TITLE
terraform: don't require deployer_role_arn

### DIFF
--- a/ci/tasks/terraform.yml
+++ b/ci/tasks/terraform.yml
@@ -33,11 +33,17 @@ run:
         ln -s "../${ALLOWED_IPS_TARGET}" ./modules/allowed-ips
       fi
 
+      BACKEND_DEPLOYER_ROLE_ARN_ARG=''
+      # also treat only-whitespace values of $DEPLOYER_ROLE_ARN as empty
+      if [ -n "$(echo $DEPLOYER_ROLE_ARN | tr -d '[:space:]')" ] ; then
+        BACKEND_DEPLOYER_ROLE_ARN_ARG="-backend-config=role_arn=${DEPLOYER_ROLE_ARN}"
+      fi
+
       terraform init -input=false \
         -backend-config "bucket=${TERRAFORM_STATE_BUCKET}" \
         -backend-config "key=github-oidc-proxy-${ENVIRONMENT_NAME}.tfstate" \
         -backend-config "region=${TERRAFORM_STATE_REGION}" \
-        -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
+        $BACKEND_DEPLOYER_ROLE_ARN_ARG
 
       terraform plan -out terraform.plan -input=false
       terraform apply -auto-approve -input=false terraform.plan

--- a/terraform/domain.tf
+++ b/terraform/domain.tf
@@ -7,7 +7,7 @@ data "terraform_remote_state" "domain_root_zone" {
     region = each.value.root_zone_tfstate_s3_region
     bucket = each.value.root_zone_tfstate_s3_bucket
     key = each.value.root_zone_tfstate_s3_key
-    role_arn = var.deployer_role_arn
+    role_arn = local.deployer_role_arn_nullable
   }
 }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -3,6 +3,8 @@ locals {
   apigw_stage_name = "main"
   api_name = "${local.service_name}-${var.environment_name}"
 
+  deployer_role_arn_nullable = trimspace(var.deployer_role_arn) != "" ? var.deployer_role_arn : null
+
   handler_names = toset([
     "token",
     "authorize",

--- a/terraform/site.tf
+++ b/terraform/site.tf
@@ -18,6 +18,6 @@ terraform {
 provider "aws" {
   region = "eu-west-2"
   assume_role {
-    role_arn = var.deployer_role_arn
+    role_arn = local.deployer_role_arn_nullable
   }
 }


### PR DESCRIPTION
Turns out we don't use this everywhere.

As ever we have to treat whitespace-only values as empty because you can't set truly empty strings for SSM secrets.