### PR TITLE
ci smoke tests: use vendored slack-notification-resource from ghcr

### DIFF
--- a/ci/smoke-tests.yml
+++ b/ci/smoke-tests.yml
@@ -6,8 +6,8 @@ resource_types:
 - name: slack-notification
   type: docker-image
   source:
-    repository: cfcommunity/slack-notification-resource
-    tag: latest
+    repository: ghcr.io/alphagov/slack-notification-resource
+    tag: 1.6.0
 
 resources:
 


### PR DESCRIPTION
Final bit of https://trello.com/c/7r1fDfR1